### PR TITLE
[!!!][TASK] Add PHP 8 compatibility, raise minimum PHP version to 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     strategy:
       matrix:
         php:
-          - 7.2
           - 7.3
           - 7.4
+          - "8.0"
 
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.php_cs.cache
+/.phpunit.result.cache
 /bin
 /composer.lock
 /vendor

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.3 || ^8.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^3.0",
@@ -22,8 +22,8 @@
         "mikey179/vfsstream": "^1.6",
         "php-parallel-lint/php-console-highlighter": "^0.5.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",
-        "phpunit/phpunit": "^6.5",
-        "slevomat/coding-standard": "^4.0",
+        "phpunit/phpunit": "^9.5",
+        "slevomat/coding-standard": "^6.4",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "config": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ version: '3'
 
 services:
   app:
-    image: thecodingmachine/php:${PHP_VERSION:-7.2}-v3-fpm
+    image: thecodingmachine/php:${PHP_VERSION:-7.3}-v4-fpm
     volumes:
       - ./:/var/www/html

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -36,11 +36,4 @@
   <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
   <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
   <rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
-  <rule ref="SlevomatCodingStandard.Types.EmptyLinesAroundTypeBraces">
-    <properties>
-      <property name="linesCountAfterOpeningBrace" type="int" value="0"/>
-      <property name="linesCountBeforeClosingBrace" type="int" value="0"/>
-    </properties>
-  </rule>
-
 </ruleset>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,7 @@
+<?xml version="1.0"?>
 <phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
   bootstrap="vendor/autoload.php"
   colors="true"
   convertErrorsToExceptions="true"
@@ -15,10 +18,9 @@
     </testsuite>
   </testsuites>
 
-  <filter>
-    <whitelist>
+  <coverage>
+    <include>
       <directory suffix=".php">src/</directory>
-    </whitelist>
-  </filter>
-
+    </include>
+  </coverage>
 </phpunit>


### PR DESCRIPTION
Hey,

I would like to use this lib in a PHP8 project, so I added support for it. Unfortunately  I had to drop support for PHP < 7.3 to upgrade the dependencies as needed.

I would love to see this merged. As it is breaking, I assume there has to be a new major release.

Please provide any feedback you have!

Patrick