### PR TITLE
[TASK] Remove explicit slevomat/coding-standard requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "php-parallel-lint/php-console-highlighter": "^0.5.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpunit/phpunit": "^9.5",
-        "slevomat/coding-standard": "^6.4",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "config": {


### PR DESCRIPTION
This package is implicitly required by cakephp/cakephp-codesniffer.

Removing the explicit dependency to this package allows for implicit updates together with cakephp/cakephp-codesniffer.