### PR TITLE
Require PHP 8.1+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - '8.0'
           - '8.1'
           - '8.2'
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.9",


### PR DESCRIPTION
PHP 8.0 is EOL since January 2024.

See https://www.php.net/supported-versions.php