### PR TITLE
Drop devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,0 @@
-{
-    "image": "thecodingmachine/php:${localEnv:PHP_VERSION:8.0}-v4-cli"
-}


### PR DESCRIPTION
We don't use this and it comes with an additional maintenance burden.